### PR TITLE
django: allow 'python manage.py <subcommand>' commands to run via llmstack

### DIFF
--- a/llmstack/cli.py
+++ b/llmstack/cli.py
@@ -255,7 +255,12 @@ def main():
 
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser("runserver")
-    subparsers.add_parser("manage.py")
+
+    # Django manage.py command setup
+    manage_py_command = subparsers.add_parser("manage.py")
+    manage_py_command.add_argument(
+        "manage_py_subcommand", help="Type 'manage.py <subcommand>' for a specific subcommand."
+    )
 
     # Load environment variables from config under [llmstack] section
     llmstack_environment = {}


### PR DESCRIPTION
Ability to open **Django manage.py <subcommand>s** using `llmstack`. Example - `llmstack manage.py shell`